### PR TITLE
Add modular AI agent with tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+\n## Modular AI Assistant\nRun the route '/assistant' to try the modular AI agent with translator, weather and calculator tools.

--- a/lib/ai_agent/ai_tool.dart
+++ b/lib/ai_agent/ai_tool.dart
@@ -1,0 +1,10 @@
+abstract class AITool {
+  String get name;
+  String get description;
+
+  /// Determine if the tool can handle the provided query.
+  bool canHandle(String query);
+
+  /// Execute the tool and return a response string.
+  Future<String> handle(String query);
+}

--- a/lib/ai_agent/modular_ai_agent.dart
+++ b/lib/ai_agent/modular_ai_agent.dart
@@ -1,0 +1,17 @@
+import 'ai_tool.dart';
+import 'tool_manager.dart';
+
+class ModularAIAgent {
+  final ToolManager toolManager;
+
+  ModularAIAgent(this.toolManager);
+
+  Future<String> process(String query) async {
+    for (final tool in toolManager.tools) {
+      if (tool.canHandle(query)) {
+        return await tool.handle(query);
+      }
+    }
+    return 'No tool available for this request.';
+  }
+}

--- a/lib/ai_agent/tool_manager.dart
+++ b/lib/ai_agent/tool_manager.dart
@@ -1,0 +1,11 @@
+import 'ai_tool.dart';
+
+class ToolManager {
+  final List<AITool> _tools = [];
+
+  List<AITool> get tools => List.unmodifiable(_tools);
+
+  void registerTool(AITool tool) {
+    _tools.add(tool);
+  }
+}

--- a/lib/ai_agent/tools/calculator_tool.dart
+++ b/lib/ai_agent/tools/calculator_tool.dart
@@ -1,0 +1,29 @@
+import 'package:math_expressions/math_expressions.dart';
+import '../ai_tool.dart';
+
+class CalculatorTool implements AITool {
+  @override
+  String get name => 'calculator';
+
+  @override
+  String get description => 'Evaluate basic arithmetic expressions.';
+
+  @override
+  bool canHandle(String query) {
+    final lower = query.toLowerCase();
+    return lower.startsWith('calc') || lower.startsWith('calculate');
+  }
+
+  @override
+  Future<String> handle(String query) async {
+    final expression = query.split(' ').sublist(1).join(' ');
+    try {
+      Parser p = Parser();
+      Expression exp = p.parse(expression);
+      double result = exp.evaluate(EvaluationType.REAL, ContextModel());
+      return result.toString();
+    } catch (e) {
+      return 'Calculation error: $e';
+    }
+  }
+}

--- a/lib/ai_agent/tools/translator_tool.dart
+++ b/lib/ai_agent/tools/translator_tool.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../ai_tool.dart';
+
+class TranslatorTool implements AITool {
+  @override
+  String get name => 'translator';
+
+  @override
+  String get description => 'Translate short text using MyMemory API';
+
+  @override
+  bool canHandle(String query) {
+    final lower = query.toLowerCase();
+    return lower.startsWith('translate') || lower.startsWith('traduire');
+  }
+
+  @override
+  Future<String> handle(String query) async {
+    try {
+      final parts = query.split(' ');
+      if (parts.length < 3) {
+        return 'Usage: translate <from>-<to> <text>';
+      }
+      final langPart = parts[1];
+      final text = parts.sublist(2).join(' ');
+      final url = Uri.parse('https://api.mymemory.translated.net/get?q=' +
+          Uri.encodeComponent(text) + '&langpair=' + langPart);
+      final response = await http.get(url);
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        return data['responseData']['translatedText'];
+      }
+      return 'Translation API error';
+    } catch (e) {
+      return 'Translation failed: $e';
+    }
+  }
+}

--- a/lib/ai_agent/tools/weather_tool.dart
+++ b/lib/ai_agent/tools/weather_tool.dart
@@ -1,0 +1,35 @@
+import 'package:http/http.dart' as http;
+import '../ai_tool.dart';
+
+class WeatherTool implements AITool {
+  @override
+  String get name => 'weather';
+
+  @override
+  String get description => 'Get current weather for a city.';
+
+  @override
+  bool canHandle(String query) {
+    final lower = query.toLowerCase();
+    return lower.startsWith('weather') || lower.startsWith('meteo');
+  }
+
+  @override
+  Future<String> handle(String query) async {
+    final parts = query.split(' ');
+    if (parts.length < 2) {
+      return 'Usage: weather <city>'; 
+    }
+    final city = parts.sublist(1).join(' ');
+    final url = Uri.parse('https://wttr.in/' + Uri.encodeComponent(city) + '?format=3');
+    try {
+      final response = await http.get(url);
+      if (response.statusCode == 200) {
+        return response.body.trim();
+      }
+      return 'Weather API error';
+    } catch (e) {
+      return 'Weather fetch failed: $e';
+    }
+  }
+}

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'views/layout/main_layout.dart';
 import 'views/auth/login_page.dart';
 import 'services/auth_service.dart';
+import 'views/assistant/modular_ai_page.dart';
 
 class AppRoutes {
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -26,6 +27,9 @@ class AppRoutes {
 
       case '/login':
         return MaterialPageRoute(builder: (_) => LoginPage());
+
+      case '/assistant':
+        return MaterialPageRoute(builder: (_) => ModularAIPage());
 
       default:
         return MaterialPageRoute(builder: (_) => LoginPage());

--- a/lib/views/assistant/modular_ai_page.dart
+++ b/lib/views/assistant/modular_ai_page.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import '../../ai_agent/modular_ai_agent.dart';
+import '../../ai_agent/tool_manager.dart';
+import '../../ai_agent/tools/translator_tool.dart';
+import '../../ai_agent/tools/weather_tool.dart';
+import '../../ai_agent/tools/calculator_tool.dart';
+
+class ModularAIPage extends StatefulWidget {
+  const ModularAIPage({Key? key}) : super(key: key);
+
+  @override
+  State<ModularAIPage> createState() => _ModularAIPageState();
+}
+
+class _ModularAIPageState extends State<ModularAIPage> {
+  late final ModularAIAgent agent;
+  final TextEditingController controller = TextEditingController();
+  String response = '';
+
+  @override
+  void initState() {
+    super.initState();
+    final manager = ToolManager();
+    manager.registerTool(TranslatorTool());
+    manager.registerTool(WeatherTool());
+    manager.registerTool(CalculatorTool());
+    agent = ModularAIAgent(manager);
+  }
+
+  Future<void> _submit() async {
+    final query = controller.text.trim();
+    if (query.isEmpty) return;
+    final result = await agent.process(query);
+    setState(() {
+      response = result;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Modular AI Assistant')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: controller,
+              decoration: const InputDecoration(
+                hintText: 'Ask something...'
+              ),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _submit,
+              child: const Text('Send'),
+            ),
+            const SizedBox(height: 24),
+            Text(response),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   rxdart: ^0.28.0
   currency_picker: ^2.0.21
   get: ^4.7.2
+  math_expressions: ^2.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- create modular AI agent architecture with `AITool`, `ToolManager`, and `ModularAIAgent`
- implement `TranslatorTool`, `WeatherTool`, and `CalculatorTool`
- add example `ModularAIPage` and route `/assistant`
- update README and pubspec for new agent

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b01b24418832096d799c7ccc38911