### PR TITLE
Improve AI chat visuals and add discount field

### DIFF
--- a/lib/models/commande.dart
+++ b/lib/models/commande.dart
@@ -4,6 +4,7 @@ class Commande extends BaseModel {
   final String numero;
   final DateTime date;
   final double montant;
+  final double remiseMontant;
   final String status;
   final String typePaiement;
   final String? clientNom;
@@ -15,6 +16,7 @@ class Commande extends BaseModel {
     required this.montant,
     required this.status,
     required this.typePaiement,
+    this.remiseMontant = 0,
     this.clientNom,
     this.payee = true,
   });
@@ -24,6 +26,7 @@ class Commande extends BaseModel {
         'id': numero,
         'date': date.toIso8601String(),
         'total': montant,
+        'remise_montant': remiseMontant,
         'statut': status,
         'moyenPaiement': typePaiement,
         'client_nom': clientNom,
@@ -36,6 +39,9 @@ class Commande extends BaseModel {
         montant: (map['total'] as num).toDouble(),
         status: map['statut'] ?? 'En attente',
         typePaiement: map['moyenPaiement'] ?? 'Non spécifié',
+        remiseMontant: (map['remise_montant'] ?? 0) is num
+            ? (map['remise_montant'] as num).toDouble()
+            : 0,
         clientNom: map['client_nom'],
         payee: map['payee'] == 1,
       );

--- a/lib/views/caisse_ia/caisse_ia_page.dart
+++ b/lib/views/caisse_ia/caisse_ia_page.dart
@@ -8,18 +8,24 @@ import 'package:url_launcher/url_launcher.dart';
 import '../../models/llm_agent_model.dart';
 
 class MessageContent {
-  final String type; // 'text', 'image', 'chart', 'pdf'
+  final String type; // 'text', 'image', 'chart', 'pdf', 'table'
   final String content;
   final Map<String, dynamic>? metadata;
+  final List<List<String>>? tableData;
+  final List<String>? headers;
 
   MessageContent({
     required this.type,
     required this.content,
     this.metadata,
+    this.tableData,
+    this.headers,
   });
 }
 
 class CaisseIAPage extends StatefulWidget {
+  const CaisseIAPage({super.key});
+
   @override
   _CaisseIAPageState createState() => _CaisseIAPageState();
 }
@@ -102,6 +108,16 @@ class _CaisseIAPageState extends State<CaisseIAPage> {
                                   content: content['content'] as String,
                                   metadata: content['metadata']
                                       as Map<String, dynamic>?,
+                                  tableData:
+                                      (content['tableData'] as List?)
+                                          ?.map<List<String>>(
+                                              (row) => (row as List)
+                                                  .map((e) => e.toString())
+                                                  .toList())
+                                          .toList(),
+                                  headers: (content['headers'] as List?)
+                                      ?.map((e) => e.toString())
+                                      .toList(),
                                 ))
                             .toList();
 
@@ -243,6 +259,24 @@ class _CaisseIAPageState extends State<CaisseIAPage> {
           ),
           child: // Intégrez ici votre widget de graphique
               Image.network(content.content), // Temporaire pour l'exemple
+        );
+
+      case 'table':
+        final headers = content.headers ?? [];
+        final rows = content.tableData ?? [];
+        return SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: DataTable(
+            columns:
+                headers.map((h) => DataColumn(label: Text(h))).toList(),
+            rows: rows
+                .map((r) => DataRow(
+                      cells: r
+                          .map((c) => DataCell(Text(c.toString())))
+                          .toList(),
+                    ))
+                .toList(),
+          ),
         );
 
       case 'pdf':

--- a/lib/views/layout/main_layout.dart
+++ b/lib/views/layout/main_layout.dart
@@ -33,6 +33,14 @@ class _MainLayoutState extends State<MainLayout> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => const CaisseIAPage()),
+          );
+        },
+        child: const Icon(Icons.smart_toy),
+      ),
       body: Row(
         children: [
           MouseRegion(


### PR DESCRIPTION
## Summary
- expose `remise_montant` in `Commande` model
- make the AI assistant accessible everywhere with a floating button
- render table responses in the AI chat interface

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b069799d88320ba6b6c2d0ca89baf