### PR TITLE
Add overlay assistant with localization and theming

### DIFF
--- a/lib/localization/app_localizations.dart
+++ b/lib/localization/app_localizations.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+class AppLocalizations {
+  final Locale locale;
+  AppLocalizations(this.locale);
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  static const Map<String, Map<String, String>> _localizedValues = {
+    'en': {
+      'home': 'Home',
+      'orders': 'Orders',
+      'history': 'History',
+      'products': 'Products / Stock',
+      'reports': 'Reports',
+      'management': 'Management',
+      'settings': 'Settings',
+      'assistant': 'AI Assistant',
+      'dark_theme': 'Dark Theme',
+      'language': 'Language',
+      'send': 'Send',
+      'ask_hint': 'Ask something...'
+    },
+    'fr': {
+      'home': 'Accueil',
+      'orders': 'Commande',
+      'history': 'Historique',
+      'products': 'Produits / Stock',
+      'reports': 'Rapports',
+      'management': 'Gestion',
+      'settings': 'Paramètres',
+      'assistant': 'Assistant IA',
+      'dark_theme': 'Thème sombre',
+      'language': 'Langue',
+      'send': 'Envoyer',
+      'ask_hint': 'Posez une question...'
+    }
+  };
+
+  String translate(String key) {
+    return _localizedValues[locale.languageCode]?[key] ??
+        _localizedValues['en']![key] ?? key;
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
+}
+
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) =>
+      ['en', 'fr'].contains(locale.languageCode);
+
+  @override
+  Future<AppLocalizations> load(Locale locale) async {
+    return AppLocalizations(locale);
+  }
+
+  @override
+  bool shouldReload(LocalizationsDelegate<AppLocalizations> old) => false;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,35 +1,49 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:scoped_model/scoped_model.dart';
 import 'services/db_helper.dart';
 import 'scoped_models/main_model.dart';
 import 'routes.dart';
+import 'localization/app_localizations.dart';
 
 void main() async {
-  // Ensure Flutter is initialized
   WidgetsFlutterBinding.ensureInitialized();
-
-  // Initialize FFI for sqflite
   await DBHelper.initializeFfi();
   await DBHelper.database;
 
-  runApp(MyApp());
+  final mainModel = MainModel();
+  await mainModel.loadSettings();
+
+  runApp(MyApp(mainModel));
 }
 
 class MyApp extends StatelessWidget {
-  final MainModel mainModel = MainModel();
+  final MainModel mainModel;
+  const MyApp(this.mainModel, {super.key});
 
   @override
   Widget build(BuildContext context) {
     return ScopedModel<MainModel>(
       model: mainModel,
-      child: MaterialApp(
-        title: 'CaissePro',
-        theme: ThemeData(
-          primarySwatch: Colors.blue,
-          useMaterial3: true,
-        ),
-        initialRoute: '/',
-        onGenerateRoute: AppRoutes.generateRoute,
+      child: ScopedModelDescendant<MainModel>(
+        builder: (context, child, model) {
+          return MaterialApp(
+            title: 'CaissePro',
+            theme: ThemeData.light().copyWith(useMaterial3: true),
+            darkTheme: ThemeData.dark().copyWith(useMaterial3: true),
+            themeMode: model.themeMode,
+            locale: model.locale,
+            supportedLocales: const [Locale('fr'), Locale('en')],
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            initialRoute: '/',
+            onGenerateRoute: AppRoutes.generateRoute,
+          );
+        },
       ),
     );
   }

--- a/lib/scoped_models/main_model.dart
+++ b/lib/scoped_models/main_model.dart
@@ -1,14 +1,45 @@
 import 'package:flutter/material.dart';
 import 'package:scoped_model/scoped_model.dart';
-import '../views/caisse_ia/caisse_ia_page.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class MainModel extends Model {
   int _currentIndex = 0;
+  ThemeMode _themeMode = ThemeMode.light;
+  Locale _locale = const Locale('fr');
+  String? _logoPath;
 
   int get currentIndex => _currentIndex;
+  ThemeMode get themeMode => _themeMode;
+  Locale get locale => _locale;
+  String? get logoPath => _logoPath;
 
   void setIndex(int index) {
     _currentIndex = index;
+    notifyListeners();
+  }
+
+  void setThemeMode(ThemeMode mode) {
+    _themeMode = mode;
+    notifyListeners();
+  }
+
+  void setLocale(Locale locale) {
+    _locale = locale;
+    notifyListeners();
+  }
+
+  void setLogoPath(String? path) {
+    _logoPath = path;
+    notifyListeners();
+  }
+
+  Future<void> loadSettings() async {
+    final prefs = await SharedPreferences.getInstance();
+    final dark = prefs.getBool('darkMode') ?? false;
+    final lang = prefs.getString('language') ?? 'fr';
+    _themeMode = dark ? ThemeMode.dark : ThemeMode.light;
+    _locale = Locale(lang);
+    _logoPath = prefs.getString('logoPath');
     notifyListeners();
   }
 }

--- a/lib/views/auth/login_page.dart
+++ b/lib/views/auth/login_page.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import '../../services/auth_service.dart';
+import 'package:scoped_model/scoped_model.dart';
+import '../../scoped_models/main_model.dart';
+import 'dart:io';
 
 class LoginPage extends StatefulWidget {
   @override
@@ -24,9 +27,17 @@ class _LoginPageState extends State<LoginPage> {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                Image.asset(
-                  'assets/images/logo.png',
-                  height: 100,
+                ScopedModelDescendant<MainModel>(
+                  builder: (context, child, model) {
+                    final path = model.logoPath;
+                    return Image(
+                      image: path != null
+                          ? FileImage(File(path))
+                              as ImageProvider
+                          : const AssetImage('assets/images/logo.png'),
+                      height: 100,
+                    );
+                  },
                 ),
                 SizedBox(height: 48),
                 Card(

--- a/lib/views/layout/main_layout.dart
+++ b/lib/views/layout/main_layout.dart
@@ -1,5 +1,5 @@
 import 'package:caissepro/views/accueil/home_page.dart';
-import 'package:caissepro/views/caisse_ia/caisse_ia_page.dart';
+// import 'package:caissepro/views/caisse_ia/caisse_ia_page.dart';
 import 'package:flutter/material.dart';
 import 'package:scoped_model/scoped_model.dart';
 import '../widgets/side_menu.dart';
@@ -10,6 +10,8 @@ import '../produits/produits_page.dart';
 import '../rapports/rapport_page.dart';
 import '../parametres/settings_page.dart';
 import '../gestion/gestion_page.dart';
+import '../assistant/assistant_chat_overlay.dart';
+import '../../localization/app_localizations.dart';
 
 class MainLayout extends StatefulWidget {
   final int selectedIndex;
@@ -33,17 +35,11 @@ class _MainLayoutState extends State<MainLayout> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          Navigator.of(context).push(
-            MaterialPageRoute(builder: (_) => const CaisseIAPage()),
-          );
-        },
-        child: const Icon(Icons.smart_toy),
-      ),
-      body: Row(
+      body: Stack(
         children: [
-          MouseRegion(
+          Row(
+            children: [
+              MouseRegion(
             onEnter: (_) => setState(() => _isExtended = true),
             onExit: (_) => setState(() => _isExtended = false),
             child: NavigationRail(
@@ -62,46 +58,46 @@ class _MainLayoutState extends State<MainLayout> {
                   _currentIndex = index;
                 });
               },
-              destinations: const [
+              destinations: [
                 NavigationRailDestination(
-                  icon: Icon(Icons.home_outlined),
-                  selectedIcon: Icon(Icons.home),
-                  label: Text('Accueil'),
+                  icon: const Icon(Icons.home_outlined),
+                  selectedIcon: const Icon(Icons.home),
+                  label: Text(AppLocalizations.of(context).translate('home')),
                 ),
                 NavigationRailDestination(
-                  icon: Icon(Icons.point_of_sale_outlined),
-                  selectedIcon: Icon(Icons.point_of_sale),
-                  label: Text('Caisse'),
+                  icon: const Icon(Icons.point_of_sale_outlined),
+                  selectedIcon: const Icon(Icons.point_of_sale),
+                  label: Text(AppLocalizations.of(context).translate('orders')),
                 ),
                 NavigationRailDestination(
-                  icon: Icon(Icons.history_outlined),
-                  selectedIcon: Icon(Icons.history),
-                  label: Text('Historique'),
+                  icon: const Icon(Icons.history_outlined),
+                  selectedIcon: const Icon(Icons.history),
+                  label:
+                      Text(AppLocalizations.of(context).translate('history')),
                 ),
                 NavigationRailDestination(
-                  icon: Icon(Icons.inventory_2_outlined),
-                  selectedIcon: Icon(Icons.inventory_2),
-                  label: Text('Produits'),
+                  icon: const Icon(Icons.inventory_2_outlined),
+                  selectedIcon: const Icon(Icons.inventory_2),
+                  label:
+                      Text(AppLocalizations.of(context).translate('products')),
                 ),
                 NavigationRailDestination(
-                  icon: Icon(Icons.bar_chart_outlined),
-                  selectedIcon: Icon(Icons.bar_chart),
-                  label: Text('Rapports'),
+                  icon: const Icon(Icons.bar_chart_outlined),
+                  selectedIcon: const Icon(Icons.bar_chart),
+                  label:
+                      Text(AppLocalizations.of(context).translate('reports')),
                 ),
                 NavigationRailDestination(
-                  icon: Icon(Icons.shopping_cart_outlined),
-                  selectedIcon: Icon(Icons.shopping_cart),
-                  label: Text('Gestion'),
+                  icon: const Icon(Icons.shopping_cart_outlined),
+                  selectedIcon: const Icon(Icons.shopping_cart),
+                  label: Text(
+                      AppLocalizations.of(context).translate('management')),
                 ),
                 NavigationRailDestination(
-                  icon: Icon(Icons.settings_outlined),
-                  selectedIcon: Icon(Icons.settings),
-                  label: Text('Paramètres'),
-                ),
-                NavigationRailDestination(
-                  icon: Icon(Icons.smart_toy_outlined),
-                  selectedIcon: Icon(Icons.smart_toy),
-                  label: Text('Assistant IA'),
+                  icon: const Icon(Icons.settings_outlined),
+                  selectedIcon: const Icon(Icons.settings),
+                  label:
+                      Text(AppLocalizations.of(context).translate('settings')),
                 ),
               ],
             ),
@@ -117,12 +113,12 @@ class _MainLayoutState extends State<MainLayout> {
                 RapportPage(),
                 GestionPage(),
                 SettingsPage(),
-                CaisseIAPage(),
               ],
             ),
           ),
         ],
       ),
+      const AssistantChatOverlay(),
     );
   }
 }

--- a/lib/views/widgets/side_menu.dart
+++ b/lib/views/widgets/side_menu.dart
@@ -3,6 +3,8 @@ import 'package:scoped_model/scoped_model.dart';
 import '../../scoped_models/main_model.dart';
 import '../../services/db_helper.dart';
 import '../../services/page_state_service.dart';
+import '../../localization/app_localizations.dart';
+import 'dart:io';
 
 class SideMenu extends StatelessWidget {
   final _pageStateService = PageStateService();
@@ -106,7 +108,10 @@ class SideMenu extends StatelessWidget {
                   padding: EdgeInsets.symmetric(vertical: 24, horizontal: 16),
                   child: Row(
                     children: [
-                      Image.asset('assets/images/logo.png', height: 32),
+                      if (model.logoPath != null)
+                        Image.file(File(model.logoPath!), height: 32)
+                      else
+                        Image.asset('assets/images/logo.png', height: 32),
                       SizedBox(width: 12),
                       Text(
                         'CaissePro',
@@ -123,118 +128,39 @@ class SideMenu extends StatelessWidget {
                   child: ListView(
                     padding: EdgeInsets.zero,
                     children: [
-                      _buildMenuItem(
-                        context: context,
-                        icon: Icons.home,
-                        title: 'Accueil',
-                        index: 0,
-                        isSelected: model.currentIndex == 0,
-                        model: model,
-                      ),
-                      _buildMenuItem(
-                        context: context,
-                        icon: Icons.shopping_cart,
-                        title: 'Commande',
-                        index: 1,
-                        isSelected: model.currentIndex == 1,
-                        model: model,
-                      ),
-                      _buildMenuItem(
-                        context: context,
-                        icon: Icons.history,
-                        title: 'Historique',
-                        index: 2,
-                        isSelected: model.currentIndex == 2,
-                        model: model,
-                      ),
-                      _buildMenuItem(
-                        context: context,
-                        icon: Icons.inventory,
-                        title: 'Produits / Stock',
-                        index: 3,
-                        isSelected: model.currentIndex == 3,
-                        model: model,
-                      ),
-                      _buildMenuItem(
-                        context: context,
-                        icon: Icons.bar_chart,
-                        title: 'Rapports',
-                        index: 4,
-                        isSelected: model.currentIndex == 4,
-                        model: model,
-                      ),
-                      _buildMenuItem(
-                        context: context,
-                        icon: Icons.settings,
-                        title: 'Gestion',
-                        index: 5,
-                        isSelected: model.currentIndex == 5,
-                        model: model,
-                      ),
-                      _buildMenuItem(
-                        context: context,
-                        icon: Icons.settings,
-                        title: 'Paramètres',
-                        index: 6,
-                        isSelected: model.currentIndex == 6,
-                        model: model,
-                      ),
+                      // Get translations
+                      ...[
+                        {'icon': Icons.home, 'key': 'home'},
+                        {'icon': Icons.shopping_cart, 'key': 'orders'},
+                        {'icon': Icons.history, 'key': 'history'},
+                        {'icon': Icons.inventory, 'key': 'products'},
+                        {'icon': Icons.bar_chart, 'key': 'reports'},
+                        {'icon': Icons.settings, 'key': 'management'},
+                        {'icon': Icons.settings, 'key': 'settings'},
+                      ].asMap().entries.map((entry) {
+                        final idx = entry.key;
+                        final item = entry.value;
+                        return _buildMenuItem(
+                          context: context,
+                          icon: item['icon'] as IconData,
+                          title: AppLocalizations.of(context)
+                              .translate(item['key'] as String),
+                          index: idx,
+                          isSelected: model.currentIndex == idx,
+                          model: model,
+                        );
+                      }).toList(),
                       Divider(height: 32),
                       _buildMenuItem(
                         context: context,
                         icon: Icons.brightness_4,
-                        title: 'Mode sombre',
+                        title:
+                            AppLocalizations.of(context).translate('dark_theme'),
                         index: 7,
                         isSelected: model.currentIndex == 7,
                         model: model,
                       ),
                     ],
-                  ),
-                ),
-                // Ajouter le bouton IA en bas
-                Container(
-                  padding: EdgeInsets.all(16),
-                  child: InkWell(
-                    onTap: () {
-                      model.setIndex(7); // Nouvel index pour la page IA
-                    },
-                    child: Container(
-                      padding: EdgeInsets.all(12),
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          colors: [Colors.blue[400]!, Colors.blue[600]!],
-                          begin: Alignment.topLeft,
-                          end: Alignment.bottomRight,
-                        ),
-                        borderRadius: BorderRadius.circular(12),
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.blue.withOpacity(0.3),
-                            blurRadius: 8,
-                            offset: Offset(0, 2),
-                          ),
-                        ],
-                      ),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Icon(
-                            Icons.smart_toy,
-                            color: Colors.white,
-                            size: 24,
-                          ),
-                          SizedBox(width: 8),
-                          Text(
-                            'Assistant IA',
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontWeight: FontWeight.bold,
-                              fontSize: 16,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
                   ),
                 ),
               ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,8 @@ dependencies:
   currency_picker: ^2.0.21
   get: ^4.7.2
   math_expressions: ^2.2.0
+  flutter_localizations:
+    sdk: flutter
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- implement simple localization with English and French
- add theme and locale settings in `MainModel`
- load settings on startup and apply to `MaterialApp`
- create `AssistantChatOverlay` and show it in `MainLayout`
- update settings to save logo and theme, and update UI logos
- support custom logo in login page and side menu

## Testing
- `flutter pub get` *(fails: flutter not installed)*
- `flutter analyze` *(fails: flutter not installed)*
- `flutter test` *(fails: flutter not installed)*


------
https://chatgpt.com/codex/tasks/task_e_684b0abdc48c8320bcfa3c0caf07b002