### PR TITLE
Implement help message in ModularAIAgent

### DIFF
--- a/lib/ai_agent/modular_ai_agent.dart
+++ b/lib/ai_agent/modular_ai_agent.dart
@@ -6,12 +6,28 @@ class ModularAIAgent {
 
   ModularAIAgent(this.toolManager);
 
+  /// Build a help message listing all available tools.
+  String _availableToolsMessage() {
+    final buffer = StringBuffer('Available tools:\n');
+    for (final tool in toolManager.tools) {
+      buffer.writeln('- ${tool.name}: ${tool.description}');
+    }
+    return buffer.toString().trim();
+  }
+
   Future<String> process(String query) async {
+    final normalized = query.trim().toLowerCase();
+
+    if (normalized == 'help') {
+      return _availableToolsMessage();
+    }
+
     for (final tool in toolManager.tools) {
       if (tool.canHandle(query)) {
         return await tool.handle(query);
       }
     }
-    return 'No tool available for this request.';
+
+    return _availableToolsMessage();
   }
 }


### PR DESCRIPTION
## Summary
- allow `ModularAIAgent` to list available tools
- return tool list when no tool can handle a query or when the user types `help`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1b4e0c208320b684fc6aa732e1cd