### PR TITLE
Fix settings persistence

### DIFF
--- a/lib/views/parametres/settings_page.dart
+++ b/lib/views/parametres/settings_page.dart
@@ -727,6 +727,12 @@ class _SettingsPageState extends State<SettingsPage> {
           backgroundColor: Colors.white,
           foregroundColor: Colors.black,
           title: Text('Paramètres système'),
+          actions: [
+            IconButton(
+              icon: Icon(Icons.save),
+              onPressed: _saveSettings,
+            ),
+          ],
         ),
         Expanded(
           child: SingleChildScrollView(
@@ -1531,7 +1537,7 @@ class _SettingsPageState extends State<SettingsPage> {
                         SizedBox(width: 16),
                         ElevatedButton(
                           onPressed: () {
-                            // Sauvegarder les paramètres
+                            _saveSettings();
                             Navigator.pop(context);
                           },
                           child: Text('Enregistrer'),


### PR DESCRIPTION
## Summary
- ensure settings are saved via a save button in the AppBar
- call saveSettings when closing receipt settings modal

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1a0834008320ab6c124d52f984bb