### PR TITLE
Integrate Gemini-based tool selection

### DIFF
--- a/lib/ai_agent/gemini_service.dart
+++ b/lib/ai_agent/gemini_service.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+import 'package:google_generative_ai/google_generative_ai.dart';
+
+class GeminiService {
+  final GenerativeModel _model;
+
+  GeminiService({required String apiKey})
+      : _model = GenerativeModel(
+          model: 'gemini-1.5-flash-latest',
+          apiKey: apiKey,
+        );
+
+  Future<Map<String, dynamic>> decideTool(
+      String query, List<String> availableTools) async {
+    final prompt = '''You are an assistant that can use tools: ${availableTools.join(', ')}.
+Decide the best tool for the user query or answer directly.
+Respond only with JSON in one of these formats:
+{ "tool": "<tool name>", "toolQuery": "<query>" }
+or
+{ "answer": "<text>" }
+Query: "$query"''';
+
+    final response = await _model.generateContent([Content.text(prompt)]);
+    return _extractJson(response.text);
+  }
+
+  Map<String, dynamic> _extractJson(String? text) {
+    if (text == null) return {};
+    final start = text.indexOf('{');
+    final end = text.lastIndexOf('}');
+    if (start == -1 || end <= start) return {};
+    final jsonStr = text.substring(start, end + 1);
+    try {
+      return jsonDecode(jsonStr);
+    } catch (_) {
+      return {};
+    }
+  }
+}

--- a/lib/ai_agent/modular_ai_agent.dart
+++ b/lib/ai_agent/modular_ai_agent.dart
@@ -1,10 +1,12 @@
 import 'ai_tool.dart';
 import 'tool_manager.dart';
+import 'gemini_service.dart';
 
 class ModularAIAgent {
   final ToolManager toolManager;
+  final GeminiService gemini;
 
-  ModularAIAgent(this.toolManager);
+  ModularAIAgent(this.toolManager, this.gemini);
 
   /// Build a help message listing all available tools.
   String _availableToolsMessage() {
@@ -20,6 +22,32 @@ class ModularAIAgent {
 
     if (normalized == 'help') {
       return _availableToolsMessage();
+    }
+
+    try {
+      final decision = await gemini.decideTool(
+          query, toolManager.tools.map((t) => t.name).toList());
+
+      if (decision.containsKey('answer')) {
+        return decision['answer'] as String;
+      }
+
+      if (decision.containsKey('tool')) {
+        final toolName = decision['tool'] as String;
+        final toolQuery = (decision['toolQuery'] ?? query) as String;
+        AITool? selected;
+        for (final t in toolManager.tools) {
+          if (t.name == toolName) {
+            selected = t;
+            break;
+          }
+        }
+        if (selected != null) {
+          return await selected.handle(toolQuery);
+        }
+      }
+    } catch (_) {
+      // Ignore Gemini errors and fall back to local tool matching
     }
 
     for (final tool in toolManager.tools) {

--- a/lib/views/assistant/assistant_chat_overlay.dart
+++ b/lib/views/assistant/assistant_chat_overlay.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../../ai_agent/modular_ai_agent.dart';
 import '../../ai_agent/tool_manager.dart';
 import '../../ai_agent/tool_registry.dart';
+import '../../ai_agent/gemini_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:get/get.dart';
 
@@ -36,7 +37,8 @@ class _AssistantChatOverlayState extends State<AssistantChatOverlay> {
         manager.registerTool(ctor());
       }
     }
-    agent = ModularAIAgent(manager);
+    final gemini = GeminiService(apiKey: 'AIzaSyCCVre0MdH35vty9lRbqQ0FglYKPt8KQ9c');
+    agent = ModularAIAgent(manager, gemini);
     setState(() => _loading = false);
   }
 

--- a/lib/views/assistant/modular_ai_page.dart
+++ b/lib/views/assistant/modular_ai_page.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import '../../ai_agent/modular_ai_agent.dart';
 import '../../ai_agent/tool_manager.dart';
 import '../../ai_agent/tool_registry.dart';
+import '../../ai_agent/gemini_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class ModularAIPage extends StatefulWidget {
@@ -35,7 +36,8 @@ class _ModularAIPageState extends State<ModularAIPage> {
         manager.registerTool(ctor());
       }
     }
-    agent = ModularAIAgent(manager);
+    final gemini = GeminiService(apiKey: 'AIzaSyCCVre0MdH35vty9lRbqQ0FglYKPt8KQ9c');
+    agent = ModularAIAgent(manager, gemini);
     setState(() => _loading = false);
   }
 


### PR DESCRIPTION
## Summary
- add `GeminiService` wrapper for Google Generative AI
- refactor `ModularAIAgent` to ask Gemini which tool to run
- hook Gemini into `ModularAIPage` and chat overlay

## Testing
- `dart format lib/ai_agent/gemini_service.dart lib/ai_agent/modular_ai_agent.dart lib/views/assistant/modular_ai_page.dart lib/views/assistant/assistant_chat_overlay.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b414e60d483209f8c3e76a5d57c8d