### PR TITLE
Seller summary with Gemini insights

### DIFF
--- a/lib/models/seller_summary.dart
+++ b/lib/models/seller_summary.dart
@@ -1,0 +1,27 @@
+class SellerSummary {
+  final int totalOrders;
+  final double totalSales;
+  final int totalClients;
+  final String peakHour;
+  final String topProductByQuantity;
+  final String topProductByRevenue;
+  final double averageBasket;
+  final double variationSinceYesterday;
+  final List<String> suggestions;
+  final List<String> stockAlerts;
+  final String motivationalMessage;
+
+  SellerSummary({
+    required this.totalOrders,
+    required this.totalSales,
+    required this.totalClients,
+    required this.peakHour,
+    required this.topProductByQuantity,
+    required this.topProductByRevenue,
+    required this.averageBasket,
+    required this.variationSinceYesterday,
+    required this.suggestions,
+    required this.stockAlerts,
+    required this.motivationalMessage,
+  });
+}

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -3,6 +3,7 @@ import 'views/layout/main_layout.dart';
 import 'views/auth/login_page.dart';
 import 'services/auth_service.dart';
 import 'views/assistant/modular_ai_page.dart';
+import 'views/assistant/seller_summary_page.dart';
 
 class AppRoutes {
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -30,6 +31,9 @@ class AppRoutes {
 
       case '/assistant':
         return MaterialPageRoute(builder: (_) => ModularAIPage());
+
+      case '/seller-summary':
+        return MaterialPageRoute(builder: (_) => const SellerSummaryPage());
 
       default:
         return MaterialPageRoute(builder: (_) => LoginPage());

--- a/lib/services/seller_summary_service.dart
+++ b/lib/services/seller_summary_service.dart
@@ -1,0 +1,97 @@
+import 'package:intl/intl.dart';
+import '../ai_agent/gemini_service.dart';
+import 'database_tools.dart';
+import '../models/seller_summary.dart';
+
+class SellerSummaryService {
+  final GeminiService gemini;
+
+  SellerSummaryService(this.gemini);
+
+  Future<SellerSummary> generateSummary(DateTime date) async {
+    final dateStr = DateFormat('yyyy-MM-dd').format(date);
+    final stats = await DatabaseTools.getStatistiquesJour(dateStr);
+
+    final totalOrders = stats['nombre_commandes'] as int? ?? 0;
+    final totalSales = (stats['total_ventes'] as num?)?.toDouble() ?? 0.0;
+    final totalClients = stats['nombre_clients'] as int? ?? 0;
+
+    final previousStats = await DatabaseTools.getStatistiquesJour(
+        DateFormat('yyyy-MM-dd').format(date.subtract(const Duration(days: 1))));
+    final prevSales = (previousStats['total_ventes'] as num?)?.toDouble() ?? 0.0;
+    final variation = prevSales == 0 ? 0 : ((totalSales - prevSales) / prevSales) * 100;
+
+    final bestSeller = await DatabaseTools.executeQuery('''
+      SELECT p.nom, SUM(cp.quantite) as qty
+      FROM commande_produits cp
+      JOIN produits p ON cp.produitId = p.id
+      JOIN commandes c ON cp.commandeId = c.id
+      WHERE date(c.date) = date(?)
+      GROUP BY p.id
+      ORDER BY qty DESC
+      LIMIT 1
+    ''', [dateStr]);
+    final topProductByQuantity = bestSeller.isNotEmpty ? bestSeller.first['nom'] as String : '-';
+
+    final bestRevenue = await DatabaseTools.executeQuery('''
+      SELECT p.nom, SUM(cp.quantite * cp.prixUnitaire) as total
+      FROM commande_produits cp
+      JOIN produits p ON cp.produitId = p.id
+      JOIN commandes c ON cp.commandeId = c.id
+      WHERE date(c.date) = date(?)
+      GROUP BY p.id
+      ORDER BY total DESC
+      LIMIT 1
+    ''', [dateStr]);
+    final topProductByRevenue = bestRevenue.isNotEmpty ? bestRevenue.first['nom'] as String : '-';
+
+    final hours = await DatabaseTools.executeQuery('''
+      SELECT strftime('%H', c.date) as hour, COUNT(*) as cnt
+      FROM commandes c
+      WHERE date(c.date) = date(?)
+      GROUP BY hour
+      ORDER BY cnt DESC
+      LIMIT 1
+    ''', [dateStr]);
+    final peakHour = hours.isNotEmpty ? '${hours.first['hour']}h' : '-';
+
+    final averageBasket = totalOrders == 0 ? 0 : totalSales / totalOrders;
+
+    final lowStock = await DatabaseTools.executeQuery('''
+      SELECT nom FROM produits WHERE stock <= seuilAlerte AND actif = 1
+    ''');
+    final stockAlerts = lowStock.map((e) => e['nom'] as String).take(3).toList();
+
+    final prompt = '''
+Génère des conseils pour améliorer les ventes demain en te basant sur :
+- Produit le plus vendu: $topProductByQuantity
+- Produit avec le plus de chiffre d'affaires: $topProductByRevenue
+- Variation par rapport à hier: ${variation.toStringAsFixed(1)}%
+Réponds par une liste de 2 à 3 phrases courtes.
+''';
+    final suggestionResp = await gemini.decideTool(prompt, []);
+    final suggestions = (suggestionResp['answer'] as String?)?.split('\n') ?? [];
+
+    final motivPrompt = '''
+Écris un court message de motivation pour un vendeur.
+Chiffre d'affaires du jour: ${totalSales.toStringAsFixed(2)} €.
+Variation par rapport à hier: ${variation.toStringAsFixed(1)}%.
+''';
+    final motivResp = await gemini.decideTool(motivPrompt, []);
+    final motivational = motivResp['answer'] as String? ?? '';
+
+    return SellerSummary(
+      totalOrders: totalOrders,
+      totalSales: totalSales,
+      totalClients: totalClients,
+      peakHour: peakHour,
+      topProductByQuantity: topProductByQuantity,
+      topProductByRevenue: topProductByRevenue,
+      averageBasket: averageBasket,
+      variationSinceYesterday: variation,
+      suggestions: suggestions,
+      stockAlerts: stockAlerts,
+      motivationalMessage: motivational,
+    );
+  }
+}

--- a/lib/views/assistant/seller_summary_page.dart
+++ b/lib/views/assistant/seller_summary_page.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../../ai_agent/gemini_service.dart';
+import '../../services/seller_summary_service.dart';
+import '../../models/seller_summary.dart';
+
+class SellerSummaryPage extends StatefulWidget {
+  const SellerSummaryPage({super.key});
+
+  @override
+  State<SellerSummaryPage> createState() => _SellerSummaryPageState();
+}
+
+class _SellerSummaryPageState extends State<SellerSummaryPage> {
+  late SellerSummaryService service;
+  SellerSummary? summary;
+  bool loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    final gemini = GeminiService(apiKey: 'AIzaSyCCVre0MdH35vty9lRbqQ0FglYKPt8KQ9c');
+    service = SellerSummaryService(gemini);
+    _loadSummary();
+  }
+
+  Future<void> _loadSummary() async {
+    final result = await service.generateSummary(DateTime.now());
+    setState(() {
+      summary = result;
+      loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Résumé intelligent de votre journée')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          setState(() => loading = true);
+          await _loadSummary();
+        },
+        child: const Icon(Icons.refresh),
+      ),
+      body: loading
+          ? const Center(child: CircularProgressIndicator())
+          : summary == null
+              ? const Center(child: Text('Aucune donnée'))
+              : SingleChildScrollView(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _buildStatsCard(),
+                      const SizedBox(height: 16),
+                      _buildAnalysisCard(),
+                      const SizedBox(height: 16),
+                      _buildSuggestionsCard(),
+                      const SizedBox(height: 16),
+                      _buildMotivationCard(),
+                    ],
+                  ),
+                ),
+    );
+  }
+
+  Widget _buildStatsCard() {
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Statistiques journalières',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 12),
+            Text('Total ventes: ${summary!.totalSales.toStringAsFixed(2)} €',
+                style: const TextStyle(fontSize: 16)),
+            Text('Nombre de commandes: ${summary!.totalOrders}',
+                style: const TextStyle(fontSize: 16)),
+            Text('Nombre de clients: ${summary!.totalClients}',
+                style: const TextStyle(fontSize: 16)),
+            Text('Panier moyen: ${summary!.averageBasket.toStringAsFixed(2)} €',
+                style: const TextStyle(fontSize: 16)),
+            Text('Heure de pic: ${summary!.peakHour}',
+                style: const TextStyle(fontSize: 16)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAnalysisCard() {
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Analyse IA de performance',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 12),
+            Text('Produit le plus vendu: ${summary!.topProductByQuantity}'),
+            Text(
+                'Produit ayant généré le plus de CA: ${summary!.topProductByRevenue}'),
+            Text(
+                'Variation vs hier: ${summary!.variationSinceYesterday.toStringAsFixed(1)}%'),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSuggestionsCard() {
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Recommandations IA',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 12),
+            ...summary!.suggestions.map((s) => Text('• $s')),
+            if (summary!.stockAlerts.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              const Text('Alertes stock:',
+                  style: TextStyle(fontWeight: FontWeight.bold)),
+              ...summary!.stockAlerts.map((s) => Text('- $s')),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMotivationCard() {
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Message de motivation',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 12),
+            Text(summary!.motivationalMessage),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a `SellerSummary` model
- implement `SellerSummaryService` to compute stats and query Gemini
- design a new `SellerSummaryPage`
- expose new page on `/seller-summary` route

## Testing
- `flutter --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684bdbc2088c8320a164843056444bbf